### PR TITLE
Allow use of remote options with BES

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BUILD
@@ -50,6 +50,8 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/network:connectivity_status",
         "//src/main/java/com/google/devtools/build/lib/profiler",
         "//src/main/java/com/google/devtools/build/lib/profiler:google-auto-profiler-utils",
+        "//src/main/java/com/google/devtools/build/lib/remote/options",
+        "//src/main/java/com/google/devtools/build/lib/remote/util",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",
         "//src/main/java/com/google/devtools/build/lib/util:detailed_exit_code",

--- a/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
+++ b/src/main/java/com/google/devtools/build/lib/buildeventservice/BuildEventServiceModule.java
@@ -52,6 +52,7 @@ import com.google.devtools.build.lib.network.ConnectivityStatus.Status;
 import com.google.devtools.build.lib.network.ConnectivityStatusProvider;
 import com.google.devtools.build.lib.profiler.AutoProfiler;
 import com.google.devtools.build.lib.profiler.GoogleAutoProfilerUtils;
+import com.google.devtools.build.lib.remote.options.RemoteOptions;
 import com.google.devtools.build.lib.runtime.BlazeModule;
 import com.google.devtools.build.lib.runtime.BuildEventArtifactUploaderFactory;
 import com.google.devtools.build.lib.runtime.BuildEventStreamer;
@@ -104,6 +105,7 @@ public abstract class BuildEventServiceModule<BESOptionsT extends BuildEventServ
 
   private BuildEventProtocolOptions bepOptions;
   private AuthAndTLSOptions authTlsOptions;
+  private RemoteOptions remoteOptions;
   private BuildEventStreamOptions besStreamOptions;
   private boolean isRunsPerTestOverTheLimit;
   private BuildEventArtifactUploaderFactory uploaderFactoryToCleanup;
@@ -174,6 +176,7 @@ public abstract class BuildEventServiceModule<BESOptionsT extends BuildEventServ
         optionsClass(),
         AuthAndTLSOptions.class,
         BuildEventStreamOptions.class,
+        RemoteOptions.class,
         BuildEventProtocolOptions.class);
   }
 
@@ -302,6 +305,7 @@ public abstract class BuildEventServiceModule<BESOptionsT extends BuildEventServ
         Preconditions.checkNotNull(parsingResult.getOptions(BuildEventProtocolOptions.class));
     this.authTlsOptions =
         Preconditions.checkNotNull(parsingResult.getOptions(AuthAndTLSOptions.class));
+    this.remoteOptions = parsingResult.getOptions(RemoteOptions.class);
     this.besStreamOptions =
         Preconditions.checkNotNull(parsingResult.getOptions(BuildEventStreamOptions.class));
     this.isRunsPerTestOverTheLimit =
@@ -676,7 +680,7 @@ public abstract class BuildEventServiceModule<BESOptionsT extends BuildEventServ
 
     final BuildEventServiceClient besClient;
     try {
-      besClient = getBesClient(besOptions, authTlsOptions);
+      besClient = getBesClient(besOptions, authTlsOptions, remoteOptions);
     } catch (IOException | OptionsParsingException e) {
       reportError(
           reporter,
@@ -821,7 +825,7 @@ public abstract class BuildEventServiceModule<BESOptionsT extends BuildEventServ
   protected abstract Class<BESOptionsT> optionsClass();
 
   protected abstract BuildEventServiceClient getBesClient(
-      BESOptionsT besOptions, AuthAndTLSOptions authAndTLSOptions)
+      BESOptionsT besOptions, AuthAndTLSOptions authAndTLSOptions, RemoteOptions remoteOptions)
       throws IOException, OptionsParsingException;
 
   protected abstract void clearBesClient();

--- a/src/main/java/com/google/devtools/build/lib/remote/util/TracingMetadataUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/remote/util/TracingMetadataUtils.java
@@ -115,6 +115,11 @@ public class TracingMetadataUtils {
     return MetadataUtils.newAttachHeadersInterceptor(metadata);
   }
 
+  public static ClientInterceptor newBESHeadersInterceptor(RemoteOptions options) {
+    Metadata metadata = newMetadataForHeaders(options.remoteHeaders);
+    return MetadataUtils.newAttachHeadersInterceptor(metadata);
+  }
+
   public static ClientInterceptor newExecHeadersInterceptor(RemoteOptions options) {
     Metadata metadata = newMetadataForHeaders(options.remoteHeaders);
     metadata.merge(newMetadataForHeaders(options.remoteExecHeaders));


### PR DESCRIPTION
Initial PoC (works in simple usecases).

todo:
- fix tests and expand coverage
- deal with possible collisions if necessary, if user manually overrides grpc metadata set by Google Auth stuff